### PR TITLE
fixes - sidecar containers graduated to stable  in 1.33

### DIFF
--- a/content/en/docs/concepts/workloads/pods/sidecar-containers.md
+++ b/content/en/docs/concepts/workloads/pods/sidecar-containers.md
@@ -5,8 +5,6 @@ weight: 50
 ---
 
 <!-- overview -->
-{{< feature-state for_k8s_version="v1.29" state="beta" >}}
-
 Sidecar containers are the secondary containers that run along with the main
 application container within the same {{< glossary_tooltip text="Pod" term_id="pod" >}}.
 These containers are used to enhance or to extend the functionality of the primary _app


### PR DESCRIPTION
According to [documentation](https://kubernetes.io/blog/2025/04/23/kubernetes-v1-33-release/#stable-sidecar-containers) side car containers are now stable.